### PR TITLE
Move to version file

### DIFF
--- a/.buildkite/pipeline.release.yml
+++ b/.buildkite/pipeline.release.yml
@@ -1,0 +1,12 @@
+steps:
+  - block: ":rocket: Release ${VERSION}?"
+
+  - label: ":s3:"
+    command: ".buildkite/steps/github-release.sh"
+    branches: master
+    agents:
+      queue: "deploy"
+    concurrency: 1
+    concurrency_group: 'release_github'
+
+

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,7 +8,8 @@ steps:
         config: .buildkite/docker-compose.yml
 
   - wait
+  - name: ":pipeline:"
+    command: .buildkite/steps/upload-release-steps.sh
 
-  - name: ":github: Release"
-    command: .buildkite/release.sh
+
 

--- a/.buildkite/steps/github-release.sh
+++ b/.buildkite/steps/github-release.sh
@@ -6,6 +6,7 @@ if [[ ! "$BUILDKITE_TAG" =~ ^v ]] ; then
   exit 0
 fi
 
+git fetch --tags
 VERSION="$(git describe --tags --candidates=1 2>/dev/null || echo dev)"
 
 download_github_release() {

--- a/.buildkite/steps/upload-release-steps.sh
+++ b/.buildkite/steps/upload-release-steps.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+export VERSION=$(awk -F\" '/const Version/ {print $2}' version/version.go)
+
+echo "Checking if $VERSION is a tag..."
+
+# If there is already a release (which means a tag), we want to avoid trying to create
+# another one, as this will fail and cause partial broken releases
+# If there is already a release (which means a tag), we want to avoid trying to create
+# another one, as this will fail and cause partial broken releases
+if git ls-remote --tags origin | grep "refs/tags/v${VERSION}" ; then
+  echo "Tag refs/tags/v${VERSION} already exists"
+  exit 0
+fi
+
+buildkite-agent pipeline upload .buildkite/pipeline.release.yml

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,7 @@
 PREFIX=github.com/lox/parfait
-VERSION=$(shell git describe --tags --candidates=1 --dirty 2>/dev/null || echo "dev")
+VERSION=v$(shell awk -F\" '/const Version/ {print $$2}' version/version.go)
 FLAGS=-X main.Version=$(VERSION) -s -w
 ARCHS=linux/amd64 darwin/amd64 windows/amd64
-
 test:
 	go get github.com/kardianos/govendor
 	govendor test +local

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,4 @@
+package version
+
+// Version the library version number
+const Version = "1.1.3"


### PR DESCRIPTION
Rather than relying on tags for the version (which are race condition prone), this adds `version/version.go`. 