### PR TITLE
No updates to be performed shouldn't fail

### DIFF
--- a/cmd/update-stack.go
+++ b/cmd/update-stack.go
@@ -43,6 +43,10 @@ func ConfigureUpdateStack(app *kingpin.Application, sess client.ConfigProvider) 
 		svc := cloudformation.New(sess)
 
 		if err = stacks.Update(svc, stackName, ctx); err != nil {
+			if stacks.IsNoUpdateErr(err) {
+				fmt.Printf("No updates to be performed, stack is up to date\n")
+				return nil
+			}
 			return err
 		}
 

--- a/stacks/cloudformation.go
+++ b/stacks/cloudformation.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 )
 
@@ -247,4 +248,14 @@ func GetError(svc cfnInterface, name string) error {
 	}
 
 	return nil
+}
+
+func IsNoUpdateErr(err error) bool {
+	if aerr, ok := err.(awserr.Error); ok {
+		if aerr.Code() == `ValidationError` &&
+			aerr.Message() == `No updates are to be performed.` {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Currently `parfait update` will fail with `ValidationError: No updates are to be performed` and a non-zero exit if there are no updates to be made. This should be a successful no-op.
